### PR TITLE
Cache Hospitality reflections

### DIFF
--- a/Source/Settings.cs
+++ b/Source/Settings.cs
@@ -18,6 +18,10 @@ namespace SoftWarmBeds
         public SoftWarmBedsMod(ModContentPack content) : base(content)
         {
             settings = GetSettings<SoftWarmBedsSettings>();
+            if (LoadedModManager.RunningModsListForReading.Any(x => x.Name == "Hospitality"))
+            {
+                ApplyBedThoughts_Patch.InitializeHospitalityReflections();
+            }
         }
 
         public override void DoSettingsWindowContents(Rect inRect)


### PR DESCRIPTION
Fixes #10 

This PR works mostly by caching every reflection info for Hospitality within the patch class, reducing performance overheads.
For the field access (`CompGuest#bed`), see [https://stackoverflow.com/a/38538377](https://stackoverflow.com/a/38538377).

Results
---
![RimWorld by Ludeon Studios 2020-05-03 오후 9_25_26](https://user-images.githubusercontent.com/9212605/80914531-0f004a00-8d87-11ea-843b-2fcd9af9696d.png)
The very first patch call takes around 10ms, which is 97% reduction.

![RimWorld by Ludeon Studios 2020-05-03 오후 9_32_15](https://user-images.githubusercontent.com/9212605/80914532-0f98e080-8d87-11ea-805e-a1fc69fd7318.png)
Any subsequent calls takes even less time, highest being 2ms, and average, less than 1ms.

Tests were done in a small scale, so it would be a good idea to test it on your side too.