### PR TITLE
Vanilla Factions Expanded - Viking support.

### DIFF
--- a/Patches/Patches_VanillaFactionExpandedVikings.xml
+++ b/Patches/Patches_VanillaFactionExpandedVikings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Vikings</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <success>Always</success>
+      <operations>
+        <!--BedRestEffectiveness Settings-->
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="VFEV_FurBed" or defName="VFEV_DoubleFurBed"]/statBases/BedRestEffectiveness</xpath>
+          <value>
+            <BedRestEffectiveness>0.47</BedRestEffectiveness>
+          </value>
+        </li>
+        <!--Comfort Settings-->
+        <li Class="PatchOperationReplace">
+          <xpath>Defs/ThingDef[defName="VFEV_FurBed" or defName="VFEV_DoubleFurBed"]/statBases/Comfort</xpath>
+          <value>
+            <Comfort>0.21</Comfort>
+          </value>
+        </li>
+        <!--Insulation Settings-->
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName="VFEV_FurBed" or defName="VFEV_DoubleFurBed"]/statBases</xpath>
+          <value>
+            <BedStuffEffectMultiplierInsulation_Cold>0.3</BedStuffEffectMultiplierInsulation_Cold>
+          </value>
+        </li>
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>


### PR DESCRIPTION
Adds a simple patch lowering the base stats of the fur bed so when the softness value gets added to it's total values it doesn't end up overpowered. The numbers I chose were flat subtractions equal to the subtraction of the normal vanilla bed except for the insulation value, which I arbitrarily chose with the objective of making the fur bed a slightly worse normal bed.