### PR TITLE
Update HarmonyPatch.cs

### DIFF
--- a/Source/HarmonyPatch.cs
+++ b/Source/HarmonyPatch.cs
@@ -490,4 +490,35 @@ namespace SoftWarmBeds
             return true;
         }
     }
+	
+	//Patchs for thingwithcomps that are not apparel that exist in recipes with apparel
+	[HarmonyPatch(typeof(SpecialThingFilterWorker_NonDeadmansApparel), "Matches")]
+	public static class Patch_SpecialThingFilterWorkerMatches
+	{
+		//Defaults all ThingWithComp objects to return true if the special filter is called for Non-DeadmansApparel. Used for niche situations when
+		//an ThingWithComp is put in the Apparel Category which causes these items to appear in recipes that use the Apparel category tag. 
+		//ex: Recyling Apparel mods
+		public static void Postfix(ref bool __result, ref Thing t)
+		{
+			if(t != null && t is ThingWithComps && !(t is Apparel))
+			{
+				__result = true;
+			}
+		}
+	}
+
+	[HarmonyPatch(typeof(SpecialThingFilterWorker_DeadmansApparel), "Matches")]
+	public static class Patch_SpecialThingFilterWorker_DeadmansApparel
+	{
+		//Defaults all ThingWithComp objects to return true if the special filter is called for Deadmans Apparel. Used for niche situations when
+		//an ThingWithComp is put in the Apparel Category which causes these items to appear in recipes that use the Apparel category tag. 
+		//ex: Recyling Apparel mods
+		public static void Postfix(ref bool __result, ref Thing t)
+		{
+			if (t != null && t is ThingWithComps && !(t is Apparel))
+			{
+				__result = false;
+			}
+		}
+	}
 }

--- a/Source/HarmonyPatch.cs
+++ b/Source/HarmonyPatch.cs
@@ -500,7 +500,7 @@ namespace SoftWarmBeds
 		//ex: Recyling Apparel mods
 		public static void Postfix(ref bool __result, ref Thing t)
 		{
-			if(t != null && t is ThingWithComps && !(t is Apparel))
+			if(t != null && t is Bedding)
 			{
 				__result = true;
 			}
@@ -515,7 +515,7 @@ namespace SoftWarmBeds
 		//ex: Recyling Apparel mods
 		public static void Postfix(ref bool __result, ref Thing t)
 		{
-			if (t != null && t is ThingWithComps && !(t is Apparel))
+			if (t != null && t is Bedding)
 			{
 				__result = false;
 			}


### PR DESCRIPTION
Added Patches to allow the beddings to qualify for the "Clean Apparel" filter in recycling Apparel recipes from other mods. Beddings by themselves do not add this filter to the recipes, they are qualifiable for the filter if another item in the recipes adds it as a filter option.