### PR TITLE
Update Patches_BabyAndChildren.xml

### DIFF
--- a/Patches/Patches_BabyAndChildren.xml
+++ b/Patches/Patches_BabyAndChildren.xml
@@ -75,7 +75,6 @@
           <xpath>/Defs/ThingDef[defName = "Crib"]</xpath>
           <value>
             <uiIconPath/>
-            <uiIconScale>1.66</uiIconScale>
           </value>
         </li>
         <li Class="JPTools.PatchOperationCopy">


### PR DESCRIPTION
to fix error:

XML error: Duplicate XML node name uiIconScale in this XML block: <ThingDef ParentName="FurnitureBase"><defName>Crib</defName><label>crib with a pillow</label><description>A high walled crib, designed to keep a young child safe through the night. With a pillow for increased comfort.</description>